### PR TITLE
Fix 4 variable errors in xlsx.js

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -20827,7 +20827,7 @@ function write_cfb_ctr(cfb, o) {
 
 function write_zip_type(wb, opts) {
 	var o = opts||{};
-	style_builder  = new StyleBuilder(opts);
+	var style_builder  = new StyleBuilder(opts);
 	var z = write_zip(wb, o);
 	var oopts = {};
 	if(o.compression) oopts.compression = 'DEFLATE';
@@ -21521,7 +21521,7 @@ var XmlNode = (function () {
     return this;
   }
 
-  var APOS = "'"; QUOTE = '"'
+  var APOS = "'", QUOTE = '"';
   var ESCAPED_QUOTE = {  }
   ESCAPED_QUOTE[QUOTE] = '&quot;'
   ESCAPED_QUOTE[APOS] = '&apos;'
@@ -21600,8 +21600,8 @@ var StyleBuilder = function (options) {
 
 
 	// cache style specs to avoid excessive duplication
-	_hashIndex = {};
-	_listIndex = [];
+	let _hashIndex = {};
+	let _listIndex = [];
 
 	return {
 


### PR DESCRIPTION
Fixes the following undefined variables in xlsx.js:
- QUOTE at line 21524
- _hashIndex at line 21603
- _listIndex at line 21604
- style_builder at line 20830

Fixes the following (closed) issues: #7 & #13

I know this repository has not been updated since November 2021, however creating a PR seems like the right thing to do.